### PR TITLE
Improve testing; resolve deprecations and linter issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ script:
   - tox
 env:
   - TOXENV=linters
-  - TOXENV=functional
+  - TOXENV=functional_1.9.4
+  - TOXENV=functional_2.1.0
+  - TOXENV=functional_stable
 notifications:
   slack:
     rooms:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+etcd_package_state: latest
+
 etcd_cluster_group: etcd
 #install type can be server or proxy. servers join the cluster as full members, while proxies operate as cluster clients
 etcd_install_type: server

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Update CA Cert index
-  shell: /usr/sbin/update-ca-certificates
+  command: /usr/sbin/update-ca-certificates
 
 - name: Reload init scripts
   command: initctl reload-configuration

--- a/tasks/etcd_install_apt.yml
+++ b/tasks/etcd_install_apt.yml
@@ -27,14 +27,6 @@
   tags:
     - etcd-apt-packages
 
-- name: Ensure host can talk to HTTPS apt repos
-  apt:
-    pkg: "apt-transport-https"
-    state: latest
-    update_cache: yes
-  tags:
-    - etcd-apt-packages
-
 - name: Add calico PPA apt-keys
   apt_key:
     id: "{{ item.hash_id }}"
@@ -99,7 +91,7 @@
 - name: Install etcd packages
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ etcd_package_state }}"
   register: install_packages
   until: install_packages | success
   retries: 5

--- a/tasks/etcd_install_yum.yml
+++ b/tasks/etcd_install_yum.yml
@@ -16,7 +16,7 @@
 - name: Install etcd yum packages
   yum:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ etcd_package_state }}"
   register: install_packages
   until: install_packages|success
   retries: 5

--- a/tasks/etcd_post_install.yml
+++ b/tasks/etcd_post_install.yml
@@ -19,7 +19,10 @@
     - etcd-config
 
 - include: etcd_post_install_ssl.yml
-  when: etcd_user_ssl_cert is defined and etcd_user_ssl_key is defined
+  static: no
+  when:
+    - "{{ etcd_user_ssl_cert is defined }}"
+    - "{{ etcd_user_ssl_key is defined }}"
 
 - name: Ensure etcd data directory exists
   file:
@@ -44,7 +47,7 @@
   meta: flush_handlers
 
 - name: Verify etcd cluster health
-  shell: "etcdctl cluster-health"
+  command: etcdctl cluster-health
   register: etcd_health
   failed_when: etcd_health.rc != 0
   until: etcd_health|success

--- a/tasks/etcd_post_install_ssl.yml
+++ b/tasks/etcd_post_install_ssl.yml
@@ -29,7 +29,8 @@
 
 - name: Ensure user CA cert dir exists
   file: path=/usr/local/share/ca-certificates state=directory
-  when: etcd_user_ssl_ca_cert is defined
+  when:
+    - "{{ etcd_user_ssl_ca_cert is defined }}"
   tags:
     - etcd-config
     - etcd-ssl
@@ -44,7 +45,8 @@
   notify: Update CA Cert index
   with_items:
     - { src: "{{ etcd_user_ssl_ca_cert }}", dest: "{{ etcd_ssl_ca_cert }}" }
-  when: etcd_user_ssl_ca_cert is defined
+  when:
+    - "{{ etcd_user_ssl_ca_cert is defined }}"
   tags:
     - etcd-config
     - etcd-ssl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
 # Detect whether the init system is upstart of systemd.
 - name: Check init system
   command: cat /proc/1/comm
+  changed_when: false
   register: _pid1_name
   tags:
     - always

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = linters,functional
+envlist = linters,functional_1.9.4,functional_2.1.0,functional_stable
 
 
 [testenv]
@@ -103,8 +103,6 @@ commands =
 [testenv:ansible]
 deps =
     {[testenv]deps}
-    ansible==1.9.4
-    ansible-lint>=2.7.0,<3.0.0
 setenv =
     {[testenv]setenv}
     ANSIBLE_HOST_KEY_CHECKING = False
@@ -131,14 +129,41 @@ commands =
                    --role-file={toxinidir}/tests/ansible-role-requirements.yml \
                    --force
 
-
-[testenv:ansible-syntax]
+[testenv:ansible_1.9.4]
 deps =
     {[testenv:ansible]deps}
+    ansible==1.9.4
 setenv =
     {[testenv:ansible]setenv}
 commands =
     {[testenv:ansible]commands}
+
+[testenv:ansible_2.1.0]
+deps =
+    {[testenv:ansible]deps}
+    ansible==2.1.0
+setenv =
+    {[testenv:ansible]setenv}
+commands =
+    {[testenv:ansible]commands}
+
+[testenv:ansible_stable]
+deps =
+    {[testenv:ansible]deps}
+    ansible
+    ansible-lint
+setenv =
+    {[testenv:ansible]setenv}
+commands =
+    {[testenv:ansible]commands}
+
+[testenv:ansible-syntax]
+deps =
+    {[testenv:ansible_stable]deps}
+setenv =
+    {[testenv:ansible_stable]setenv}
+commands =
+    {[testenv:ansible_stable]commands}
     ansible-playbook -i {toxinidir}/tests/inventory \
                      --syntax-check \
                      --list-tasks \
@@ -148,34 +173,61 @@ commands =
 
 [testenv:ansible-lint]
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_stable]deps}
 commands =
     ansible-lint {toxinidir}
 
 
-[testenv:functional]
-# NOTE(odyssey4me): this target does not use constraints because
-# it doesn't work in OpenStack-CI yet. Once that's fixed, we can
-# drop the install_command.
+[testenv:functional_1.9.4]
 install_command =
     pip install -U --force-reinstall {opts} {packages}
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_1.9.4]deps}
 setenv =
-    {[testenv:ansible]setenv}
+    {[testenv:ansible_1.9.4]setenv}
 commands =
-    {[testenv:ansible]commands}
+    {[testenv:ansible_1.9.4]commands}
     ansible-playbook -i {toxinidir}/tests/inventory \
                      -e "rolename={toxinidir}" \
                      -e "install_test_packages=True" \
                      {toxinidir}/tests/test.yml -vvvv
 
 
+[testenv:functional_2.1.0]
+install_command =
+   pip install -U --force-reinstall {opts} {packages}
+deps =
+   {[testenv:ansible_2.1.0]deps}
+setenv =
+   {[testenv:ansible_2.1.0]setenv}
+commands =
+   {[testenv:ansible_2.1.0]commands}
+   ansible-playbook -i {toxinidir}/tests/inventory \
+                    -e "rolename={toxinidir}" \
+                    -e "install_test_packages=True" \
+                    {toxinidir}/tests/test.yml -vvvv
+
+
+[testenv:functional_stable]
+install_command =
+   pip install -U --force-reinstall {opts} {packages}
+deps =
+   {[testenv:ansible_stable]deps}
+setenv =
+   {[testenv:ansible_stable]setenv}
+commands =
+   {[testenv:ansible_stable]commands}
+   ansible-playbook -i {toxinidir}/tests/inventory \
+                    -e "rolename={toxinidir}" \
+                    -e "install_test_packages=True" \
+                    {toxinidir}/tests/test.yml -vvvv
+
+
 [testenv:linters]
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_stable]deps}
 setenv =
-    {[testenv:ansible]setenv}
+    {[testenv:ansible_stable]setenv}
 commands =
     {[testenv:pep8]commands}
     {[testenv:bashate]commands}


### PR DESCRIPTION
Adds tox scenarios for ansible 1.9.4, 2.1.0, and latest stable.

Runs linter using latest stable ansible.

Resolves var deprecations and linter issues

This resolves #4 by setting static=no on the user ssl task file include.
