### PR TITLE
Add restart to systemd unit on unclean exit

### DIFF
--- a/templates/systemd-etcd-override.conf.j2
+++ b/templates/systemd-etcd-override.conf.j2
@@ -1,2 +1,5 @@
 [Service]
 EnvironmentFile={{ etcd_conf_dir }}/etcd.conf
+Restart=on-failure
+RestartSec=10
+


### PR DESCRIPTION
When the etcd process exits uncleanly due to issues like
https://github.com/coreos/etcd/issues/5267 then have the systemd
unit restart the service.