### PR TITLE
Replace legacy API healthcheck

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -27,7 +27,7 @@
       changed_when: false
     - name: Test etcd cluster health
       uri:
-        url: "{{ etcd_url_scheme }}://127.0.0.1:{{ etcd_client_port }}/health"
+        url: "http://127.0.0.1:2379/health"
         return_content: true
       register: etcd_health
       changed_when: false

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -28,7 +28,7 @@
     - name: Test etcd cluster health
       uri:
         url: "{{ etcd_url_scheme }}://127.0.0.1:{{ etcd_client_port }}/health"
-        return_content: yes
+        return_content: true
       register: etcd_health
       changed_when: false
     - name: Check role functions

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -26,11 +26,13 @@
       register: etcd_proc
       changed_when: false
     - name: Test etcd cluster health
-      command: etcdctl cluster-health
+      uri:
+        url: "{{ etcd_url_scheme }}://127.0.0.1:{{ etcd_client_port }}/health"
+        return_content: yes
       register: etcd_health
       changed_when: false
     - name: Check role functions
       assert:
         that:
-          - "'cluster is healthy' in etcd_health.stdout"
+          - "'true' in etcd_health.content"
       changed_when: false

--- a/tasks/etcd_post_install_server.yml
+++ b/tasks/etcd_post_install_server.yml
@@ -64,7 +64,7 @@
 - name: Verify etcd cluster health
   uri:
     url: "{{ etcd_url_scheme }}://127.0.0.1:{{ etcd_client_port }}/health"
-    return_content: yes
+    return_content: true
   register: etcd_health
   failed_when: "'true' not in etcd_health.content"
   changed_when: false

--- a/tasks/etcd_post_install_server.yml
+++ b/tasks/etcd_post_install_server.yml
@@ -62,14 +62,15 @@
             LimitNOFILE: 65536
 
 - name: Verify etcd cluster health
-  command: etcdctl cluster-health
+  uri:
+    url: "{{ etcd_url_scheme }}://127.0.0.1:{{ etcd_client_port }}/health"
+    return_content: yes
   register: etcd_health
-  failed_when: etcd_health.rc != 0
+  failed_when: "'true' not in etcd_health.content"
   changed_when: false
   until: etcd_health is success
   retries: 5
   delay: 2
-  when: inventory_hostname == groups[etcd_cluster_group][0]
   tags:
     - etcd-config
     - etcd-verify


### PR DESCRIPTION
As from version 3.4 `ETCDCTL_API=3` is the default so `cluster-health` command does not work. I decided to replace it with another method.